### PR TITLE
fix(manifest.toml): ldap support & remove optional redis-server

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -25,7 +25,7 @@ helpers_version = "2.1"
 architectures = "all"
 multi_instance = true
 
-ldap = false
+ldap = true
 sso = false
 
 disk = "900M"
@@ -61,7 +61,7 @@ ram.runtime = "1G"
     [resources.ports]
 
     [resources.apt]
-    packages = "mariadb-server, redis-server"
+    packages = "mariadb-server"
 
     [resources.database]
     type = "mysql"


### PR DESCRIPTION
LDAP is natively supported & redis-server is not needed by default.